### PR TITLE
Fallback to bin/bundle when bundle command fails

### DIFF
--- a/lib/search_gem_view.coffee
+++ b/lib/search_gem_view.coffee
@@ -31,17 +31,19 @@ class SearchGemView extends SelectListView
        @setItems(list)
    else
     # [todo] show error dialog
- getGems: (callback)->
+ getGems: (callback, bundleCommand = "bundle")->
    return callback(cache) if cache
-   exec "cd #{@projectPath} && bundle show", (err, stdout, stderr)=>
+   exec "cd #{@projectPath} && #{bundleCommand} show", (err, stdout, stderr)=>
+     return @getGems(callback, "bin/bundle") if err
      cache = stdout.split("\n").map (gem)->
        gem.replace(/^[^\w\d]+/g, '')
      callback(cache)
  viewForItem: (item) ->
    "<li>#{item}</li>"
- confirmed: (item) ->
+ confirmed: (item, bundleCommand = "bundle") ->
    item = item.replace(/\s\(.*?\)$/, '')
-   exec "cd #{@projectPath} && bundle show #{item}", (err, stdout, stderr)=>
+   exec "cd #{@projectPath} && #{bundleCommand} show #{item}", (err, stdout, stderr)=>
+     return @confirmed(item, "bin/bundle") if err
      atom.open(pathsToOpen: [stdout]);
    @hide()
 

--- a/lib/search_gem_view.coffee
+++ b/lib/search_gem_view.coffee
@@ -34,7 +34,7 @@ class SearchGemView extends SelectListView
  getGems: (callback, bundleCommand = "bundle")->
    return callback(cache) if cache
    exec "cd #{@projectPath} && #{bundleCommand} show", (err, stdout, stderr)=>
-     return @getGems(callback, "bin/bundle") if err
+     return @getGems(callback, "bin/bundle") if err and bundleCommand != "bin/bundle"
      cache = stdout.split("\n").map (gem)->
        gem.replace(/^[^\w\d]+/g, '')
      callback(cache)
@@ -43,7 +43,7 @@ class SearchGemView extends SelectListView
  confirmed: (item, bundleCommand = "bundle") ->
    item = item.replace(/\s\(.*?\)$/, '')
    exec "cd #{@projectPath} && #{bundleCommand} show #{item}", (err, stdout, stderr)=>
-     return @confirmed(item, "bin/bundle") if err
+     return @confirmed(item, "bin/bundle") if err and bundleCommand != "bin/bundle"
      atom.open(pathsToOpen: [stdout]);
    @hide()
 


### PR DESCRIPTION
Rails 4 [introduced app executables, including `bin/bundle`, to the `bin` directory](https://github.com/rails/rails/commit/009873aec89a4b843b41accf616b42b7a9917ba8#diff-1846d4882fa63eb5b1271541995cbfdc). Running `bin/bundle` ensures Bundler uses the application's Ruby version and bundled gems.

Depending on the project and the developer's environment, `bundle show` may not work correctly, but `bin/bundle show` might. This change adds `bin/bundle` as a fallback bundler command if `bundle` fails.

